### PR TITLE
Feat:minimal reject cache inserts on DOI collision

### DIFF
--- a/src/bibtex.ts
+++ b/src/bibtex.ts
@@ -187,6 +187,32 @@ export function check_duplicate_id(bibtex_dict: BibtexDict, id: string, file_pat
 }
 
 /**
+ * Check if a BibTeX DOI is already used by another cached entry.
+ * @param bibtex_dict - The dictionary of BibTeX entries.
+ * @param doi - The DOI to check.
+ * @param id - The ID of the entry being checked (same id + path is not a clash).
+ * @param file_path - The path of the file to check.
+ * @returns True if the DOI is duplicated, false otherwise.
+ */
+export function check_duplicate_doi(bibtex_dict: BibtexDict, doi: string | undefined, id: string, file_path: string): boolean {
+    // no doi to enforce
+    if (!doi) {
+        return false
+    }
+
+    // if another entry already has this doi, it's a clash
+    // (the same entry re-rendered from the same file is fine)
+    for (const cached_id in bibtex_dict) {
+        const entry = bibtex_dict[cached_id]
+        if (entry.fields.doi === doi && !(cached_id === id && entry.source_path == file_path)) {
+            return true
+        }
+    }
+
+    return false
+}
+
+/**
  * Check if a BibTeX entry matches a search query.
  * Format: <query>;<query>;...
  * Each query could be a string or a <key>:<value> pair. Only the paper that matches all queries will be considered a match.

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { App, Editor, Notice, Plugin, Setting, PluginSettingTab, MarkdownRenderer, MarkdownRenderChild, normalizePath, type MarkdownPostProcessorContext } from 'obsidian'
-import { parse_bibtex, make_bibtex, check_duplicate_id, FetchBibtexOnline, type BibtexDict } from 'src/bibtex'
+import { parse_bibtex, make_bibtex, check_duplicate_id, check_duplicate_doi, FetchBibtexOnline, type BibtexDict } from 'src/bibtex'
 import { render_hover } from 'src/hover'
 import { EditorPrompt, FolderSuggest, FileSuggest } from 'src/prompt'
 import { PaperPanelView, PAPER_PANEL_VIEW_TYPE } from 'src/panel'
@@ -186,15 +186,24 @@ export default class BibtexScholar extends Plugin {
 		fields_ls.forEach(async (fields) => {
 			const id = fields.id
 			const bibtex_source = make_bibtex(fields)
-			const duplicate = check_duplicate_id(
+			const id_duplicate = check_duplicate_id(
 				this.cache.bibtex_dict, id,
 				ctx.sourcePath,
 				String(ctx.getSectionInfo(el)?.text)
 			)
+			const doi_duplicate = check_duplicate_doi(
+				this.cache.bibtex_dict, fields.doi, id, ctx.sourcePath
+			)
+			const duplicate = id_duplicate || doi_duplicate
 
 			if (duplicate) {
 				// if duplicated, prompt warning
-				new Notice(`Warning: BibTeX ID has been used\n${id}`, 10e3)
+				if (id_duplicate) {
+					new Notice(`Warning: BibTeX ID has been used\n${id}`, 10e3)
+				}
+				if (doi_duplicate) {
+					new Notice(`Warning: BibTeX DOI has been used\n${fields.doi}`, 10e3)
+				}
 			} else {
 				// if not duplicated, check if the id exists
 				// if exists, only cache bibtex code that is updated
@@ -210,10 +219,16 @@ export default class BibtexScholar extends Plugin {
 			}
 
 			// render paper element
+			// if doi-clash rejected a new id, fall back to the local fields so it still paints
 			const paper_bar = el.createEl('span', {
 				cls: (duplicate) ? ('bibtex-hover-duplicate-id') : ('bibtex-entry'),
 			})
-			render_hover(paper_bar, this.cache.bibtex_dict[id], this, this.app)
+			const entry = this.cache.bibtex_dict[id] ?? {
+				fields: fields,
+				source: bibtex_source,
+				source_path: ctx.sourcePath,
+			}
+			render_hover(paper_bar, entry, this, this.app)
 			el.createEl('code').setText('source')
 		})
 	}


### PR DESCRIPTION
Citation keys alone are not enough: both ids point at the same citable document. Unique exact match. Behavior matches key clash. addresses #8.